### PR TITLE
Switch ReactRouter to BrowserRouter

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,14 +3,14 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import * as serviceWorker from './serviceWorker';
 import { Main } from './pages/MasterPage';
-import { HashRouter, } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import WebFont from 'webfontloader';
 
 ReactDOM.render(
   <React.StrictMode>
-    <HashRouter basename={process.env.PUBLIC_URL}>
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
       <Main />
-    </HashRouter>
+    </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
This PR changes from HashRouter to BrowserRouter so that website pages are denoted with a `/` instead of a `#`.