### PR TITLE
Move FAQ component & text in Death Tracker page to FAQ page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,10 @@
 module.exports = {
-  extends: ['plugin:react/recommended', 'plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended', 'plugin:react-hooks/recommended'],
+  extends: [
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+    'plugin:react-hooks/recommended',
+  ],
   plugins: ['react', '@typescript-eslint', 'prettier'],
   env: {
     browser: true,
@@ -28,7 +33,7 @@ module.exports = {
         caughtErrorsIgnorePattern: '^_',
       },
     ],
-    'prettier/prettier': ['warn'],
+    'prettier/prettier': ['error'],
   },
   settings: {
     react: {

--- a/src/components/ContentLayout.tsx
+++ b/src/components/ContentLayout.tsx
@@ -6,10 +6,12 @@ type ContentLayoutProps = {
   title: string;
 };
 
+export const CustomDivider: React.FC = () => <Divider className={styles.contentlayoutdivider} />;
+
 const ContentLayout: React.FC<ContentLayoutProps> = (props) => {
   return (
     <div className={styles.contentlayoutcontainer}>
-      <Divider className={styles.contentlayoutdivider} />
+      <CustomDivider />
       <div className={styles.contentlayouttitlecontainer}>
         <Typography.Title>{props.title}</Typography.Title>
       </div>

--- a/src/components/CustomTitle.tsx
+++ b/src/components/CustomTitle.tsx
@@ -1,14 +1,16 @@
 import { Divider, Typography } from 'antd';
 import React from 'react';
 
+import styles from '../styles/CustomTitle.module.less';
+
 type CustomTitleProps = {
   title: string;
 };
 
 const CustomTitle: React.FC<CustomTitleProps> = (props) => (
-  <div>
-    <Divider />
-    <Typography.Title>{props.title}</Typography.Title>
+  <div className={styles.titlecontainer}>
+    <Divider className={styles.titledivider} />
+    <Typography.Title level={3}>{props.title}</Typography.Title>
   </div>
 );
 

--- a/src/components/CustomTitle.tsx
+++ b/src/components/CustomTitle.tsx
@@ -1,0 +1,15 @@
+import { Divider, Typography } from 'antd';
+import React from 'react';
+
+type CustomTitleProps = {
+  title: string;
+};
+
+const CustomTitle: React.FC<CustomTitleProps> = (props) => (
+  <div>
+    <Divider />
+    <Typography.Title>{props.title}</Typography.Title>
+  </div>
+);
+
+export default CustomTitle;

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Collapse, Typography } from 'antd';
 import '../styles/FAQ.less';
-import { FAQ_data } from '../content/FAQContent';
+import { IFAQ } from '../content/FAQContent';
 
-const FAQ: React.FC = () => {
+const FAQ: React.FC<{ data: IFAQ[] }> = (props) => {
   return (
     <div className="faq-container">
       <Collapse
@@ -20,7 +20,7 @@ const FAQ: React.FC = () => {
         }
         expandIconPosition="right"
       >
-        {FAQ_data.map((f, i) => (
+        {props.data.map((f, i) => (
           <Collapse.Panel
             className={`faq-collapse-panel-${i}`}
             key={i}

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -172,7 +172,7 @@ const RenderMenu: React.FC<MenuProps> = (props: MenuProps) => {
           setSelected([`${InternalRoutes.RESOURCES.key}`]);
         }}
       >
-        FAQ
+        Resources
       </Menu.Item>
     </Menu>
   );

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -94,8 +94,8 @@ const RenderMenu: React.FC<MenuProps> = (props: MenuProps) => {
      */
     if (location.pathname === InternalRoutes.HOME.path) {
       setSelected([`${InternalRoutes.HOME.key}`]);
-    } else if (location.pathname === InternalRoutes.FAQ.path) {
-      setSelected([`${InternalRoutes.FAQ.key}`]);
+    } else if (location.pathname === InternalRoutes.RESOURCES.path) {
+      setSelected([`${InternalRoutes.RESOURCES.key}`]);
     } else if (location.pathname === InternalRoutes.TEAM.path) {
       setSelected([`${InternalRoutes.TEAM.key}`]);
     } else if (location.pathname === InternalRoutes.PUBLICATIONS.path) {
@@ -165,11 +165,11 @@ const RenderMenu: React.FC<MenuProps> = (props: MenuProps) => {
         Our Team
       </Menu.Item>
       <Menu.Item
-        key={InternalRoutes.FAQ.key}
+        key={InternalRoutes.RESOURCES.key}
         className={styles.MenuItem}
         onClick={() => {
-          navigate(InternalRoutes.FAQ.path);
-          setSelected([`${InternalRoutes.FAQ.key}`]);
+          navigate(InternalRoutes.RESOURCES.path);
+          setSelected([`${InternalRoutes.RESOURCES.key}`]);
         }}
       >
         FAQ

--- a/src/content/FAQContent.ts
+++ b/src/content/FAQContent.ts
@@ -30,3 +30,6 @@ export const FAQ_data: IFAQ[] = [
       'A death investigation system refers to the system used for assigning cause of death on the death certificates. In the US, this system varies from place to place, and sometimes involves a medical examiner or a coroner.',
   },
 ];
+
+export const text_content =
+  'This website features tools for identifying both patterns of county excess mortality throughout the United States and potential underreported COVID-19 deaths';

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 interface TableauVizElement {
   'hide-tabs'?: boolean;
   toolbar?: 'top' | 'bottom' | 'hidden';

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -1,4 +1,3 @@
-import { Col, Row, Space, Typography } from 'antd';
 import Paragraph from 'antd/lib/typography/Paragraph';
 import Title from 'antd/lib/typography/Title';
 import React from 'react';

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -1,11 +1,39 @@
+import { Col, Row, Space, Typography } from 'antd';
+import Paragraph from 'antd/lib/typography/Paragraph';
+import Title from 'antd/lib/typography/Title';
 import React from 'react';
 import ContentLayout from '../components/ContentLayout';
 import FAQ from '../components/FAQ';
 import { FAQ_data } from '../content/FAQContent';
+import * as Content from '../content/TrackerPageContent';
+
+import styles from '../styles/FAQPage.module.less';
 
 const FAQPage: React.FC = () => {
   return (
     <ContentLayout title="FREQUENTLY ASKED QUESTION">
+      <div className={styles.faqpagetext}>
+        <div>
+          <Title level={3} underline>
+            {Content.about_title}
+          </Title>
+          <Title level={4}>{Content.about_1_title}</Title>
+          <Paragraph>{Content.about_1_body}</Paragraph>
+          <Title level={4}>{Content.about_2_title}</Title>
+          <Paragraph>{Content.about_2_body}</Paragraph>
+        </div>
+        <div>
+          <Title level={3} underline>
+            {Content.key_terms_title}
+          </Title>
+          <Title level={4}>{Content.term_1_title}</Title>
+          <Paragraph>{Content.term_2_body}</Paragraph>
+          <Title level={4}>{Content.term_2_title}</Title>
+          <Paragraph>{Content.term_2_body}</Paragraph>
+          <Title level={4}>{Content.term_3_title}</Title>
+          <Paragraph>{Content.term_3_body}</Paragraph>
+        </div>
+      </div>
       <FAQ data={FAQ_data} />
     </ContentLayout>
   );

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import ContentLayout from '../components/ContentLayout';
+import FAQ from '../components/FAQ';
+import { FAQ_data } from '../content/FAQContent';
 
 const FAQPage: React.FC = () => {
   return (
-    <div>
-      <p>FAQ Page</p>
-    </div>
+    <ContentLayout title="FREQUENTLY ASKED QUESTION">
+      <FAQ data={FAQ_data} />
+    </ContentLayout>
   );
 };
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -6,7 +6,6 @@ import * as Content from '../content/LandingPageContent';
 import Title from 'antd/lib/typography/Title';
 import Paragraph from 'antd/lib/typography/Paragraph';
 import ViewTrackerButton from '../components/ViewTrackerButton';
-import FAQ from '../components/FAQ';
 
 export const LandingPage: React.FC = () => {
   return (
@@ -38,11 +37,6 @@ export const LandingPage: React.FC = () => {
           <Col span={6}></Col>
         </Row>
       </Space>
-      <Row>
-        <Col span={24}>
-          <FAQ />
-        </Col>
-      </Row>
     </Layout.Content>
   );
 };

--- a/src/pages/MasterPage.tsx
+++ b/src/pages/MasterPage.tsx
@@ -9,7 +9,7 @@ import { Page404 } from './404Page';
 import { PublicationsPage } from './PublicationsPage';
 
 import OurTeamPage from './OurTeamPage';
-import FAQPage from './FAQPage';
+import ResourcesPage from './ResourcesPage';
 import { MainFooter } from '../components/Footer';
 import { InternalRoutes } from '../routes';
 import MediaPage from './MediaPage';
@@ -33,7 +33,7 @@ export const Main: React.FC = () => {
           <Route path={InternalRoutes.TRACKER.path} element={<TrackerPage />}></Route>
           <Route path={InternalRoutes.PUBLICATIONS.path} element={<PublicationsPage />}></Route>
           <Route path={InternalRoutes.TEAM.path} element={<OurTeamPage />}></Route>
-          <Route path={InternalRoutes.FAQ.path} element={<FAQPage />}></Route>
+          <Route path={InternalRoutes.RESOURCES.path} element={<ResourcesPage />}></Route>
           <Route path={InternalRoutes.MEDIA.path} element={<MediaPage />}></Route>
           <Route path="/" element={<Page404 />}>
             {/* <Page404 /> */}

--- a/src/pages/OurTeamPage.tsx
+++ b/src/pages/OurTeamPage.tsx
@@ -19,11 +19,13 @@ const MemberCard: React.FC<MemberCardProps> = (props) => {
 const OurTeamPage: React.FC = () => {
   return (
     <ContentLayout title="OUR TEAM">
-      <Space style={{ marginTop: '10%' }} size={80} direction="vertical">
-        {content.map((c) => (
-          <MemberCard key={c.imgSrc} {...c} />
-        ))}
-      </Space>
+      <div style={{ width: '100%', textAlign: 'center' }}>
+        <Space style={{ marginTop: '10%' }} size={80} direction="vertical">
+          {content.map((c) => (
+            <MemberCard key={c.imgSrc} {...c} />
+          ))}
+        </Space>
+      </div>
     </ContentLayout>
   );
 };

--- a/src/pages/ResourcesPage.tsx
+++ b/src/pages/ResourcesPage.tsx
@@ -1,39 +1,19 @@
-import Paragraph from 'antd/lib/typography/Paragraph';
-import Title from 'antd/lib/typography/Title';
 import React from 'react';
 import ContentLayout from '../components/ContentLayout';
+import CustomTitle from '../components/CustomTitle';
 import FAQ from '../components/FAQ';
-import { FAQ_data } from '../content/FAQContent';
-import * as Content from '../content/TrackerPageContent';
-
-import styles from '../styles/FAQPage.module.less';
+import { FAQ_data, text_content } from '../content/FAQContent';
 
 const ResourcesPage: React.FC = () => {
   return (
-    <ContentLayout title="RESOURCES">
-      <div className={styles.faqpagetext}>
-        <div>
-          <Title level={3} underline>
-            {Content.about_title}
-          </Title>
-          <Title level={4}>{Content.about_1_title}</Title>
-          <Paragraph>{Content.about_1_body}</Paragraph>
-          <Title level={4}>{Content.about_2_title}</Title>
-          <Paragraph>{Content.about_2_body}</Paragraph>
-        </div>
-        <div>
-          <Title level={3} underline>
-            {Content.key_terms_title}
-          </Title>
-          <Title level={4}>{Content.term_1_title}</Title>
-          <Paragraph>{Content.term_2_body}</Paragraph>
-          <Title level={4}>{Content.term_2_title}</Title>
-          <Paragraph>{Content.term_2_body}</Paragraph>
-          <Title level={4}>{Content.term_3_title}</Title>
-          <Paragraph>{Content.term_3_body}</Paragraph>
-        </div>
+    <ContentLayout title="RESOURCES" text={text_content}>
+      <div>
+        <CustomTitle title="FEMA" />
       </div>
-      <FAQ data={FAQ_data} />
+      <div>
+        <CustomTitle title="FREQUENTLY ASKED QUESTIONS" />
+        <FAQ data={FAQ_data} />
+      </div>
     </ContentLayout>
   );
 };

--- a/src/pages/ResourcesPage.tsx
+++ b/src/pages/ResourcesPage.tsx
@@ -8,9 +8,9 @@ import * as Content from '../content/TrackerPageContent';
 
 import styles from '../styles/FAQPage.module.less';
 
-const FAQPage: React.FC = () => {
+const ResourcesPage: React.FC = () => {
   return (
-    <ContentLayout title="FREQUENTLY ASKED QUESTION">
+    <ContentLayout title="RESOURCES">
       <div className={styles.faqpagetext}>
         <div>
           <Title level={3} underline>
@@ -38,4 +38,4 @@ const FAQPage: React.FC = () => {
   );
 };
 
-export default FAQPage;
+export default ResourcesPage;

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import Title from 'antd/lib/typography/Title';
 import TableauView from '../components/TableauView';
-
+import * as Content from '../content/TrackerPageContent';
 import ContentLayout from '../components/ContentLayout';
+import Paragraph from 'antd/lib/typography/Paragraph';
+
+import styles from '../styles/TrackerPage.module.less';
 
 export const TrackerPage: React.FC = () => {
   return (
@@ -11,6 +14,28 @@ export const TrackerPage: React.FC = () => {
         <Title level={2}>Interactive Map</Title>
       </div>
       <TableauView />
+      <div className={styles.faqpagetext}>
+        <div>
+          <Title level={3} underline>
+            {Content.about_title}
+          </Title>
+          <Title level={4}>{Content.about_1_title}</Title>
+          <Paragraph>{Content.about_1_body}</Paragraph>
+          <Title level={4}>{Content.about_2_title}</Title>
+          <Paragraph>{Content.about_2_body}</Paragraph>
+        </div>
+        <div>
+          <Title level={3} underline>
+            {Content.key_terms_title}
+          </Title>
+          <Title level={4}>{Content.term_1_title}</Title>
+          <Paragraph>{Content.term_2_body}</Paragraph>
+          <Title level={4}>{Content.term_2_title}</Title>
+          <Paragraph>{Content.term_2_body}</Paragraph>
+          <Title level={4}>{Content.term_3_title}</Title>
+          <Paragraph>{Content.term_3_body}</Paragraph>
+        </div>
+      </div>
     </ContentLayout>
   );
 };

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { Row, Layout, Typography, Col } from 'antd';
 import Title from 'antd/lib/typography/Title';
 import TableauView from '../components/TableauView';
 
-import styles from '../styles/TrackerPage.module.less';
 import ContentLayout from '../components/ContentLayout';
 
 export const TrackerPage: React.FC = () => {

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -7,7 +7,9 @@ import ContentLayout from '../components/ContentLayout';
 export const TrackerPage: React.FC = () => {
   return (
     <ContentLayout title="EXCESS DEATH TRACKER">
-      <Title level={2}>Interactive Map</Title>
+      <div style={{ textAlign: 'center' }}>
+        <Title level={2}>Interactive Map</Title>
+      </div>
       <TableauView />
     </ContentLayout>
   );

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -1,53 +1,16 @@
 import React from 'react';
-import { Row, Col, Layout, Typography, Space } from 'antd';
-import * as Content from '../content/TrackerPageContent';
+import { Row, Layout, Typography, Col } from 'antd';
 import Title from 'antd/lib/typography/Title';
-import Paragraph from 'antd/lib/typography/Paragraph';
 import TableauView from '../components/TableauView';
+
+import styles from '../styles/TrackerPage.module.less';
+import ContentLayout from '../components/ContentLayout';
 
 export const TrackerPage: React.FC = () => {
   return (
-    <Layout.Content>
-      <Row justify="center">
-        <Typography>
-          <Title level={2}>Excess Death Tracker - Interactive Map</Title>
-        </Typography>
-      </Row>
-      <Row justify="center">
-        <Col span={24}>
-          <TableauView />
-        </Col>
-      </Row>
-      <Space direction="vertical" size={75}>
-        <Row>
-          <Col span={6}></Col>
-          <Col span={12}>
-            <Typography>
-              <Title level={5}>{Content.about_title}</Title>
-              <Title>{Content.about_1_title}</Title>
-              <Paragraph>{Content.about_1_body}</Paragraph>
-              <Title>{Content.about_2_title}</Title>
-              <Paragraph>{Content.about_2_body}</Paragraph>
-            </Typography>
-          </Col>
-          <Col span={6}></Col>
-        </Row>
-        <Row>
-          <Col span={6}></Col>
-          <Col span={12}>
-            <Typography>
-              <Title level={5}>{Content.key_terms_title}</Title>
-              <Title>{Content.term_1_title}</Title>
-              <Paragraph>{Content.term_2_body}</Paragraph>
-              <Title>{Content.term_2_title}</Title>
-              <Paragraph>{Content.term_2_body}</Paragraph>
-              <Title>{Content.term_3_title}</Title>
-              <Paragraph>{Content.term_3_body}</Paragraph>
-            </Typography>
-          </Col>
-          <Col span={6}></Col>
-        </Row>
-      </Space>
-    </Layout.Content>
+    <ContentLayout title="EXCESS DEATH TRACKER">
+      <Title level={2}>Interactive Map</Title>
+      <TableauView />
+    </ContentLayout>
   );
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,7 +7,7 @@ export const InternalRoutes = {
   PARTNERS: { path: '/partners', key: 4 },
   ABOUT: { path: '/about', key: 5 },
   TRACKER: { path: '/tracker', key: 6 },
-  FAQ: { path: '/faq', key: 7 },
+  RESOURCES: { path: '/resources', key: 7 },
   PUBLICATIONS: { path: '/publications', key: 8 },
   MEDIA: { path: '/media', key: 9 },
   TEAM: { path: '/team', key: 10 },

--- a/src/styles/ContentLayout.module.less
+++ b/src/styles/ContentLayout.module.less
@@ -1,6 +1,5 @@
 .contentlayoutcontainer {
   width: 100vw;
-  text-align: center;
   padding: 5% 10%;
 }
 

--- a/src/styles/ContentLayout.module.less
+++ b/src/styles/ContentLayout.module.less
@@ -2,7 +2,7 @@
 
 .contentlayoutcontainer {
   width: 100vw;
-  padding: 5% 10%;
+  padding: 3% 9%;
 }
 
 .contentlayoutdivider {

--- a/src/styles/CustomTitle.module.less
+++ b/src/styles/CustomTitle.module.less
@@ -1,9 +1,12 @@
 .titledivider {
   border-top: 9px solid @primary-color;
+  width: 8rem;
+  min-width: 0;
 }
 
 .titlecontainer {
-  > h1 {
+  > h3 {
     color: @primary-color;
+    margin-bottom: 3rem;
   }
 }

--- a/src/styles/CustomTitle.module.less
+++ b/src/styles/CustomTitle.module.less
@@ -1,0 +1,9 @@
+.titledivider {
+  border-top: 9px solid @primary-color;
+}
+
+.titlecontainer {
+  > h1 {
+    color: @primary-color;
+  }
+}

--- a/src/styles/FAQ.less
+++ b/src/styles/FAQ.less
@@ -1,5 +1,4 @@
 .faq-container {
-  padding: 1rem 10rem;
     .faq-collapse-content {
         line-height: 2.6rem;
     }

--- a/src/styles/FAQ.less
+++ b/src/styles/FAQ.less
@@ -1,3 +1,5 @@
+@import './themes.less';
+
 .faq-container {
     .faq-collapse-content {
         line-height: 2.6rem;
@@ -8,6 +10,7 @@
     .ant-collapse-header {
         .ant-typography {
             margin: 0;
+            font-size: @font-large-size;
         }
     } 
     .ant-collapse-content {

--- a/src/styles/FAQPage.module.less
+++ b/src/styles/FAQPage.module.less
@@ -1,0 +1,7 @@
+@import './themes.less';
+
+.faqpagetext {
+  text-align: start;
+  font-size: @font-normal-size;
+  margin-bottom: 12%;
+}

--- a/src/styles/TableauView.module.less
+++ b/src/styles/TableauView.module.less
@@ -1,4 +1,3 @@
 .TableauViewBox {
-  padding: 0 15%;
+  padding: 0 5rem;
 }
-

--- a/src/styles/TrackerPage.module.less
+++ b/src/styles/TrackerPage.module.less
@@ -1,0 +1,7 @@
+@import './themes.less';
+
+.trackpagetext {
+  text-align: start;
+  font-size: @font-normal-size;
+  margin-bottom: 12%;
+}


### PR DESCRIPTION
**Changes:**
- small changes in other pages to keep the style align with the design
- moved FAQ components and text from deatht tracker page to FAQ page

**Notes:**
- this is created with the assumption that the pages will have similar structure to publication, media and team pages