### PR TITLE
Add Linter Action

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -1,0 +1,24 @@
+name: ESLint Format and Style
+
+on:
+  pull_request:
+  push:
+    branches:
+      - react_transfer
+      - main
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm ci # or yarn install
+      - uses: sibiraj-s/action-eslint@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }} # Optional
+          eslint-args: '--ignore-path=.gitignore --quiet'
+          extensions: 'js,jsx,ts,tsx'
+          annotations: true


### PR DESCRIPTION
This adds a github action to run the linter and annotate files that are out of compliance.

We can't test it until it's merged into `react_transfer` branch. The action won't run until then.