### PR TITLE
Mobile modal

### DIFF
--- a/src/components/WarningModal.tsx
+++ b/src/components/WarningModal.tsx
@@ -15,7 +15,7 @@ const WarningModal: React.FC = () => {
     >
       <p>
         For the best experience we recommend viewing the excess death tracker on your desktop
-        device. We currently working to improve the mobile site.
+        device. We are currently working to improve the mobile site.
       </p>
     </Modal>
   );

--- a/src/components/WarningModal.tsx
+++ b/src/components/WarningModal.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { Modal } from 'antd';
 import { isMobile } from 'react-device-detect';
+import styles from '../styles/WarningModal.module.less';
 
 const WarningModal: React.FC = () => {
   const [isVisible, setVisible] = useState(isMobile);
   return (
     <Modal
+      className={styles.Title}
       visible={isVisible}
       title="Mobile Warning"
       closable={true}

--- a/src/components/WarningModal.tsx
+++ b/src/components/WarningModal.tsx
@@ -1,30 +1,24 @@
 import React, { useState } from 'react';
 import { Modal } from 'antd';
+import { isMobile } from 'react-device-detect';
 
-interface Props {
-  isMobile: boolean;
-}
-
-export const WarningModal: React.FC<Props> = (props: Props) => {
-  const { isMobile } = props;
-  const [isVisible, setVisible] = useState(true);
+const WarningModal: React.FC = () => {
+  const [isVisible, setVisible] = useState(isMobile);
   return (
-    <>
-      {isMobile ? (
-        <Modal
-          visible={isVisible}
-          title="Mobile Warning"
-          closable={true}
-          centered={true}
-          onCancel={() => setVisible(false)}
-          footer={null}
-        >
-          <p>
-            For the best experience we recommend viewing the excess death tracker on your desktop
-            device. We currently working to improve the mobile site.
-          </p>
-        </Modal>
-      ) : null}
-    </>
+    <Modal
+      visible={isVisible}
+      title="Mobile Warning"
+      closable={true}
+      centered={true}
+      onCancel={() => setVisible(false)}
+      footer={null}
+    >
+      <p>
+        For the best experience we recommend viewing the excess death tracker on your desktop
+        device. We currently working to improve the mobile site.
+      </p>
+    </Modal>
   );
 };
+
+export default WarningModal;

--- a/src/components/WarningModal.tsx
+++ b/src/components/WarningModal.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Modal } from 'antd';
+
+interface Props {
+  isMobile: boolean;
+}
+
+export const WarningModal: React.FC<Props> = (props: Props) => {
+  const { isMobile } = props;
+  const [isVisible, setVisible] = useState(true);
+  return (
+    <>
+      {isMobile ? (
+        <Modal
+          visible={isVisible}
+          title="Mobile Warning"
+          closable={true}
+          centered={true}
+          onCancel={() => setVisible(false)}
+          footer={null}
+        >
+          <p>
+            For the best experience we recommend viewing the excess death tracker on your desktop
+            device. We currently working to improve the mobile site.
+          </p>
+        </Modal>
+      ) : null}
+    </>
+  );
+};

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -5,13 +5,12 @@ import ContentLayout from '../components/ContentLayout';
 import styles from '../styles/TrackerPage.module.less';
 import { Typography } from 'antd';
 import CustomTitle from '../components/CustomTitle';
-import { isMobile } from 'react-device-detect';
-import { WarningModal } from '../components/WarningModal';
+import WarningModal from '../components/WarningModal';
 
 export const TrackerPage: React.FC = () => {
   return (
     <ContentLayout title="EXCESS DEATH TRACKER" text={Content.text_content} marginBottom={'3rem'}>
-      <WarningModal isMobile={isMobile} />
+      <WarningModal />
       <div style={{ fontSize: '1.2rem', marginBottom: '4rem' }}>
         <Typography.Text strong>{Content.description_tableau}</Typography.Text>
       </div>

--- a/src/pages/TrackerPage.tsx
+++ b/src/pages/TrackerPage.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import TableauView from '../components/TableauView';
 import * as Content from '../content/TrackerPageContent';
 import ContentLayout from '../components/ContentLayout';
-
 import styles from '../styles/TrackerPage.module.less';
 import { Typography } from 'antd';
 import CustomTitle from '../components/CustomTitle';
+import { isMobile } from 'react-device-detect';
+import { WarningModal } from '../components/WarningModal';
 
 export const TrackerPage: React.FC = () => {
   return (
     <ContentLayout title="EXCESS DEATH TRACKER" text={Content.text_content} marginBottom={'3rem'}>
+      <WarningModal isMobile={isMobile} />
       <div style={{ fontSize: '1.2rem', marginBottom: '4rem' }}>
         <Typography.Text strong>{Content.description_tableau}</Typography.Text>
       </div>

--- a/src/styles/WarningModal.module.less
+++ b/src/styles/WarningModal.module.less
@@ -1,4 +1,3 @@
-@import './globalSettings.module.less';
 
 .Title { 
     text-align: center;

--- a/src/styles/WarningModal.module.less
+++ b/src/styles/WarningModal.module.less
@@ -1,0 +1,6 @@
+@import './globalSettings.module.less';
+
+.Title { 
+    text-align: center;
+    font-size: 1.5rem;
+}


### PR DESCRIPTION
https://trello.com/c/lyMfrZlP/45-add-a-disclaimer-banner-on-mobile-advising-that-this-experience-is-better-on-desktop

Right now the font looks a little large for the warning - I'm assuming that's because it uses rem? 

![Screenshot from 2022-04-13 15-50-52](https://user-images.githubusercontent.com/73002018/163259122-e04ab0f5-8c49-4768-969d-770345c2b9d3.png)

