### PR TITLE
Fix media pub image

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -9,6 +9,7 @@ import CustomTitle from '../components/CustomTitle';
 import { content as mediaContent } from '../content/MediaPageContent';
 import { ContentCard } from './PublicationsPage';
 import { content as pubContent } from '../content/PublicationsPageContent';
+import { isMobile } from 'react-device-detect';
 
 export const LandingPage: React.FC = () => {
   return (
@@ -37,7 +38,7 @@ export const LandingPage: React.FC = () => {
           <CustomTitle title="RECENT MEDIA" />
           <div className={cardStyles.pubgridlayout}>
             {mediaContent.slice(0, 2).map((mc) => (
-              <ContentCard key={mc.title} imgAligned="flex-start" {...mc} />
+              <ContentCard key={mc.title} imgAligned={isMobile ? 'center' : 'flex-start'} {...mc} />
             ))}
           </div>
         </div>
@@ -45,7 +46,7 @@ export const LandingPage: React.FC = () => {
           <CustomTitle title="PUBLICATIONS" />
           <div className={cardStyles.pubgridlayout}>
             {pubContent.slice(0, 2).map((pc) => (
-              <ContentCard key={pc.title} imgAligned="flex-start" {...pc} />
+              <ContentCard key={pc.title} imgAligned={isMobile ? 'center' : 'flex-start'} {...pc} />
             ))}
           </div>
         </div>

--- a/src/pages/PublicationsPage.tsx
+++ b/src/pages/PublicationsPage.tsx
@@ -26,7 +26,7 @@ export const ContentCard: React.FC<ContentCardProps> = (props) => {
           }}
         />
       </div>
-      <div style={{ flex: 2, justifyContent: 'space-between' }}>
+      <div className={styles.pubcardtext}>
         <div style={{ margin: 0 }}>
           <Typography.Title level={3}>{props.title}</Typography.Title>
           <Typography.Text className={styles.pubcarddate}>{props.date}</Typography.Text>

--- a/src/styles/ContentLayout.module.less
+++ b/src/styles/ContentLayout.module.less
@@ -1,7 +1,7 @@
 @import './themes.less';
 
 .contentlayoutcontainer {
-  width: 100vw;
+  width: 100%;
   padding: calc(@navbar-height + 3rem) 9%;
 }
 

--- a/src/styles/LandingPage.module.less
+++ b/src/styles/LandingPage.module.less
@@ -34,6 +34,7 @@
     display: flex;
     flex-direction: column;
     padding: 0 @screen-padding;
+    overflow-x: hidden;
 }
 
 // Needs to be changed

--- a/src/styles/MasterPage.module.less
+++ b/src/styles/MasterPage.module.less
@@ -3,7 +3,6 @@
 @import 'themes.less';
 
 .MasterLayout {
-  width: 100vw;
   padding: 0;
 }
 
@@ -24,7 +23,6 @@
 .MasterFooter {
   background-color: #DBDBDB;
   text-align: center;
-  width: 100vw;
 }
 
 .MasterFooterText {
@@ -40,7 +38,7 @@
   height: @navbar-height;
   display: flex;
   flex-direction: column;
-  width: 100vw;
+  width: 100%;
 }
 
 .MenuCol {

--- a/src/styles/MasterPage.module.less
+++ b/src/styles/MasterPage.module.less
@@ -7,10 +7,8 @@
 }
 
 .FooterLogo {
-  display: flex;
-  align-items: left;
   padding: 1.25rem;
-  width: 48rem;
+  max-width: 60%;
 }
 
 .MasterContent {
@@ -22,7 +20,8 @@
 
 .MasterFooter {
   background-color: #DBDBDB;
-  text-align: center;
+  display: flex;
+  align-items: flex-start;
 }
 
 .MasterFooterText {

--- a/src/styles/OurTeamPage.module.less
+++ b/src/styles/OurTeamPage.module.less
@@ -1,7 +1,6 @@
 @import './themes.less';
 
 .ourteampage {
-  width: 100vw;
   text-align: center;
   padding: 10%;
 }

--- a/src/styles/PublicationsPage.module.less
+++ b/src/styles/PublicationsPage.module.less
@@ -40,6 +40,10 @@
   }
 }
 
+.pubimagecontainer {
+  
+}
+
 .pubcarddate {
   color: @warm-grey;
   font-size: @font-small-size;

--- a/src/styles/PublicationsPage.module.less
+++ b/src/styles/PublicationsPage.module.less
@@ -40,8 +40,10 @@
   }
 }
 
-.pubimagecontainer {
-  
+.pubcardtext {
+  flex: 2;
+  justify-content: space-between;
+  padding-left: 2rem;
 }
 
 .pubcarddate {
@@ -76,6 +78,11 @@
         line-height: 3rem;
       }
     }
+  }
+
+  .pubcardtext {
+    padding-left: 0;
+    padding: 0 2rem;
   }
 
   .pubgridlayout {


### PR DESCRIPTION
- [task](https://trello.com/c/Qdw6TSfK/74-fix-the-images-on-media-publications-and-recent-media-publication)
- [task](https://trello.com/c/v47Np4og/79-text-in-footer-in-mobile-overflows)

**Changes:**
- added paddings to the text so that image and text of content card won't touch each other
- fixed stlying that cause the website to overflow from max view width