### PR TITLE
changed hook

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -20,10 +20,10 @@ export const LandingPage: React.FC = () => {
           <div className={styles.LandingPageOverlayText}>
             <div>
               <div className={styles.underlineoverlay}>
-                <strong>Millions</strong>
+                <strong>180,000+</strong>
                 <span />
               </div>
-              &nbsp;of deaths from COVID-19 are underreported.
+              &nbsp;deaths have gone uncounted across the US during the Covid-19 pandemic.
             </div>
             <ViewTrackerButton content="View excess death tracker" />
           </div>

--- a/src/styles/LandingPage.module.less
+++ b/src/styles/LandingPage.module.less
@@ -78,13 +78,15 @@
     font-size: 4rem; 
     font-weight: bold;
     line-height: 1;
+    z-index: 55;
     }
    > span {
        position: absolute;
-       border-bottom: 0.5rem solid #3b9ec2;
-       width: 80%;
-       bottom: 0;
-       right: -0.3rem;
+       border-bottom: 0.8rem solid #3b9ec2;
+       width: 98.5%;
+       bottom: -0.1rem;
+       right: 0;
+       z-index: 50;
    }
 }
 


### PR DESCRIPTION
I noticed that banner image on the live site is slightly "shorter" than the zeplin wireframe, as in there is less space above the lady's head to put the text. I think it makes sense so the user doesn't have to scroll as far but should I shrink the text down in turn to fit it above the lady's head? @minkyoseo @IanSaucy 